### PR TITLE
feat: add responsive image sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -53,3 +53,19 @@ body {
 .right {
     transform: rotate(90deg);
 }
+
+@media (max-width: 600px) {
+    #countdownImage,
+    .player-image {
+        width: 40vw;
+        max-width: 150px;
+        height: auto;
+    }
+
+    #choices img {
+        width: 20vw;
+        max-width: 80px;
+        height: auto;
+        margin: 5px;
+    }
+}


### PR DESCRIPTION
## Summary
- Add responsive `@media` query to shrink countdown and player images on screens narrower than 600px
- Scale choice buttons with relative units and auto height for better fit on small devices

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0804cb0f8832fa5435f8a388f827e