### PR TITLE
Add scoreboard and round outcome display

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,11 @@
             <img id="rightResult" class="player-image" src="" alt="Right player">
         </div>
 
+        <p id="resultText"></p>
+        <div id="scoreboard">
+            Player: <span id="playerScore">0</span> | Computer: <span id="computerScore">0</span>
+        </div>
+
         <audio id="rpsAudio" src="RPS.wav"></audio>
 
         <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -13,6 +13,11 @@ const resultDiv = document.getElementById('result');
 const leftResult = document.getElementById('leftResult');
 const rightResult = document.getElementById('rightResult');
 const audio = document.getElementById('rpsAudio');
+const resultText = document.getElementById('resultText');
+const playerScoreSpan = document.getElementById('playerScore');
+const computerScoreSpan = document.getElementById('computerScore');
+let playerScore = 0;
+let computerScore = 0;
 
 startButton.addEventListener('click', () => {
     startButton.style.display = 'none';
@@ -50,10 +55,29 @@ function showChoices() {
 }
 
 function showResult(playerChoice) {
-    const leftChoice = choices[Math.floor(Math.random() * 3)];
-    leftResult.src = images[leftChoice];
+    const computerChoice = choices[Math.floor(Math.random() * 3)];
+    leftResult.src = images[computerChoice];
     rightResult.src = images[playerChoice];
     leftResult.className = 'player-image left';
     rightResult.className = 'player-image right';
     resultDiv.style.display = 'block';
+
+    let outcome;
+    if (playerChoice === computerChoice) {
+        outcome = "It's a tie!";
+    } else if (
+        (playerChoice === 'Rock' && computerChoice === 'Scissors') ||
+        (playerChoice === 'Paper' && computerChoice === 'Rock') ||
+        (playerChoice === 'Scissors' && computerChoice === 'Paper')
+    ) {
+        outcome = 'You win!';
+        playerScore++;
+    } else {
+        outcome = 'Computer wins!';
+        computerScore++;
+    }
+
+    resultText.textContent = outcome;
+    playerScoreSpan.textContent = playerScore;
+    computerScoreSpan.textContent = computerScore;
 }

--- a/style.css
+++ b/style.css
@@ -50,6 +50,16 @@ body {
     transform: rotate(-90deg);
 }
 
+#resultText {
+    font-weight: bold;
+    margin-top: 20px;
+}
+
+#scoreboard {
+    font-weight: bold;
+    margin-top: 10px;
+}
+
 .right {
     transform: rotate(90deg);
 }


### PR DESCRIPTION
## Summary
- add round result text and scoreboard to UI
- style scoreboard and result text
- track player/computer scores and display round outcomes

## Testing
- `npx htmlhint index.html` (fails: The attribute [ src ] of the tag [ img ] must have a value.)
- `npx stylelint style.css` (fails: No configuration provided)
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68a0812be4c8832f9771024c12df2f46