### PR TITLE
Replace choice images with buttons and add keyup support

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
         </div>
 
         <div id="choices" style="display:none;">
-            <img class="choice" data-choice="Rock" src="Rock.png" alt="Rock">
-            <img class="choice" data-choice="Paper" src="Paper.png" alt="Paper">
-            <img class="choice" data-choice="Scissors" src="Scissors.png" alt="Scissors">
+            <button class="choice" data-choice="Rock"><img src="Rock.png" alt="Rock"></button>
+            <button class="choice" data-choice="Paper"><img src="Paper.png" alt="Paper"></button>
+            <button class="choice" data-choice="Scissors"><img src="Scissors.png" alt="Scissors"></button>
         </div>
 
         <div id="result" style="display:none;">

--- a/script.js
+++ b/script.js
@@ -34,11 +34,17 @@ replayButton.addEventListener('click', () => {
     startButton.style.display = 'inline-block';
 });
 
-Array.from(document.getElementsByClassName('choice')).forEach(img => {
-    img.addEventListener('click', () => {
-        const playerChoice = img.getAttribute('data-choice');
+document.querySelectorAll('.choice').forEach(button => {
+    const handleChoice = () => {
+        const playerChoice = button.getAttribute('data-choice');
         choicesDiv.style.display = 'none';
         playCountdown(() => showResult(playerChoice));
+    };
+    button.addEventListener('click', handleChoice);
+    button.addEventListener('keyup', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            handleChoice();
+        }
     });
 });
 

--- a/style.css
+++ b/style.css
@@ -36,15 +36,22 @@ body {
     height: 200px;
 }
 
-#choices img {
+
+.choice {
+    border: none;
+    background: none;
+    cursor: pointer;
+    padding: 0;
+}
+
+.choice img {
     width: 100px;
     height: 100px;
     margin: 10px;
-    cursor: pointer;
     transition: transform 0.2s;
 }
 
-#choices img:hover {
+.choice:hover img {
     transform: scale(1.1);
 }
 
@@ -80,7 +87,7 @@ body {
         height: auto;
     }
 
-    #choices img {
+    .choice img {
         width: 20vw;
         max-width: 80px;
         height: auto;


### PR DESCRIPTION
## Summary
- wrap RPS choices in button elements for better semantics
- remove default button styles while keeping hover scaling
- handle Enter/Space keyup to trigger choices

## Testing
- `node --check script.js`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a0837bb080832fab948b2323292578