### PR TITLE
Streamline rock-paper-scissors round and show upright results

### DIFF
--- a/script.js
+++ b/script.js
@@ -43,7 +43,7 @@ Promise.all(
 
 startButton.addEventListener('click', () => {
     startButton.style.display = 'none';
-    playCountdown(showChoices);
+    showChoices();
 });
 
 muteButton.addEventListener('click', () => {
@@ -79,15 +79,15 @@ function playCountdown(callback) {
     countdownDiv.style.display = 'block';
     audio.currentTime = 0;
     audio.play();
-    countdownImage.src = images[choices[index % 3]];
+    countdownImage.src = images[choices[index]];
     const interval = setInterval(() => {
         index++;
-        if (index >= 6) {
+        if (index >= choices.length) {
             clearInterval(interval);
             countdownDiv.style.display = 'none';
             callback();
         } else {
-            countdownImage.src = images[choices[index % 3]];
+            countdownImage.src = images[choices[index]];
         }
     }, 1000);
 }
@@ -102,8 +102,8 @@ function showResult(playerChoice) {
     rightResult.src = images[playerChoice];
     leftResult.alt = leftChoice;
     rightResult.alt = playerChoice;
-    leftResult.className = 'player-image left';
-    rightResult.className = 'player-image right';
+    leftResult.className = 'player-image';
+    rightResult.className = 'player-image';
     resultDiv.style.display = 'block';
 
     let outcome;

--- a/style.css
+++ b/style.css
@@ -62,8 +62,9 @@ body {
     margin: 0 20px;
 }
 
+/* Display result images upright */
 .left {
-    transform: rotate(-90deg);
+    transform: none;
 }
 
 #resultText {
@@ -77,7 +78,7 @@ body {
 }
 
 .right {
-    transform: rotate(90deg);
+    transform: none;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Show choice buttons before countdown so selection happens first
- Run countdown once through Rock, Paper, Scissors then reveal result
- Display result images upright with player's choice on right and NPC on left

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a087efa394832fb7a2b053a7f4b1b7