### PR TITLE
Show player choice on left side of results

### DIFF
--- a/script.js
+++ b/script.js
@@ -97,22 +97,22 @@ function showChoices() {
 }
 
 function showResult(playerChoice) {
-    const leftChoice = choices[Math.floor(Math.random() * 3)];
-    leftResult.src = images[leftChoice];
-    rightResult.src = images[playerChoice];
-    leftResult.alt = leftChoice;
-    rightResult.alt = playerChoice;
+    const computerChoice = choices[Math.floor(Math.random() * 3)];
+    leftResult.src = images[playerChoice];
+    rightResult.src = images[computerChoice];
+    leftResult.alt = playerChoice;
+    rightResult.alt = computerChoice;
     leftResult.className = 'player-image';
     rightResult.className = 'player-image';
     resultDiv.style.display = 'block';
 
     let outcome;
-    if (playerChoice === leftChoice) {
+    if (playerChoice === computerChoice) {
         outcome = "It's a tie!";
     } else if (
-        (playerChoice === 'Rock' && leftChoice === 'Scissors') ||
-        (playerChoice === 'Paper' && leftChoice === 'Rock') ||
-        (playerChoice === 'Scissors' && leftChoice === 'Paper')
+        (playerChoice === 'Rock' && computerChoice === 'Scissors') ||
+        (playerChoice === 'Paper' && computerChoice === 'Rock') ||
+        (playerChoice === 'Scissors' && computerChoice === 'Paper')
     ) {
         outcome = 'You win!';
         playerScore++;


### PR DESCRIPTION
## Summary
- Fix `showResult` to display the player's image on the left and computer's on the right
- Compare against `computerChoice` throughout result evaluation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a089b52a60832fab040c6b45aa793f