### PR TITLE
Improve button and choice styling with hover effects

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,6 +21,38 @@ body {
     padding: 10px 20px;
     font-size: 16px;
     cursor: pointer;
+    border: none;
+    border-radius: 8px;
+    color: #fff;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s, background-color 0.2s;
+}
+
+#startButton {
+    background-color: #28a745;
+}
+
+#startButton:hover {
+    background-color: #218838;
+    transform: scale(1.05);
+}
+
+#replayButton {
+    background-color: #007bff;
+}
+
+#replayButton:hover {
+    background-color: #0069d9;
+    transform: scale(1.05);
+}
+
+#muteButton {
+    background-color: #dc3545;
+}
+
+#muteButton:hover {
+    background-color: #c82333;
+    transform: scale(1.05);
 }
 
 #countdown,
@@ -49,11 +81,15 @@ body {
     width: 100px;
     height: 100px;
     margin: 10px;
-    transition: transform 0.2s;
+    border: 4px solid #ffffff;
+    border-radius: 10px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .choice:hover img {
     transform: scale(1.1);
+    box-shadow: 0 0 20px rgba(255, 255, 255, 0.8);
 }
 
 .player-image {


### PR DESCRIPTION
## Summary
- Give start, replay, and mute buttons distinct colors, rounded corners, shadows, and hover scaling
- Add colored borders and bright hover glow to choice images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a08c5f30b0832f87ca16345c25a671