### PR TITLE
Add outcome styling and score highlighting

### DIFF
--- a/script.js
+++ b/script.js
@@ -28,6 +28,9 @@ const computerScoreSpan = document.getElementById('computerScore');
 let playerScore = 0;
 let computerScore = 0;
 
+playerScoreSpan.classList.add('tie');
+computerScoreSpan.classList.add('tie');
+
 // Wait for all images to load before enabling the start button
 startButton.disabled = true;
 Promise.all(
@@ -55,6 +58,7 @@ replayButton.addEventListener('click', () => {
     resultDiv.style.display = 'none';
     replayButton.style.display = 'none';
     resultText.textContent = '';
+    resultText.classList.remove('win', 'lose', 'tie');
     leftResult.src = '';
     rightResult.src = '';
     startButton.style.display = 'inline-block';
@@ -106,23 +110,44 @@ function showResult(playerChoice) {
     rightResult.className = 'player-image';
     resultDiv.style.display = 'block';
 
-    let outcome;
+    let outcome, outcomeClass;
     if (playerChoice === computerChoice) {
         outcome = "It's a tie!";
+        outcomeClass = 'tie';
     } else if (
         (playerChoice === 'Rock' && computerChoice === 'Scissors') ||
         (playerChoice === 'Paper' && computerChoice === 'Rock') ||
         (playerChoice === 'Scissors' && computerChoice === 'Paper')
     ) {
         outcome = 'You win!';
+        outcomeClass = 'win';
         playerScore++;
     } else {
         outcome = 'Computer wins!';
+        outcomeClass = 'lose';
         computerScore++;
     }
 
     resultText.textContent = outcome;
+    resultText.classList.remove('win', 'lose', 'tie');
+    resultText.classList.add(outcomeClass);
+
     playerScoreSpan.textContent = playerScore;
     computerScoreSpan.textContent = computerScore;
+
+    playerScoreSpan.classList.remove('win', 'lose', 'tie');
+    computerScoreSpan.classList.remove('win', 'lose', 'tie');
+
+    if (playerScore > computerScore) {
+        playerScoreSpan.classList.add('win');
+        computerScoreSpan.classList.add('lose');
+    } else if (playerScore < computerScore) {
+        playerScoreSpan.classList.add('lose');
+        computerScoreSpan.classList.add('win');
+    } else {
+        playerScoreSpan.classList.add('tie');
+        computerScoreSpan.classList.add('tie');
+    }
+
     replayButton.style.display = 'block';
 }

--- a/style.css
+++ b/style.css
@@ -113,6 +113,18 @@ body {
     margin-top: 10px;
 }
 
+.win {
+    color: green;
+}
+
+.lose {
+    color: red;
+}
+
+.tie {
+    color: gray;
+}
+
 .right {
     transform: none;
 }


### PR DESCRIPTION
## Summary
- Add win/lose/tie CSS classes for colored feedback
- Apply outcome classes to result text and highlight the leading score in the scoreboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a08d11e7c0832f95c05e0daf1bada3